### PR TITLE
Añadir nombre del grupo en la página web

### DIFF
--- a/servidor.py
+++ b/servidor.py
@@ -19,6 +19,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         <body>
             <h1>Hola desde un servidor Python</h1>
             <p>Este es un servidor simple que responde a solicitudes GET.</p>
+            <p>Web del grupo DAS 404 FOUND.</p>
         </body>
         </html>"""
 

--- a/test_servidor.py
+++ b/test_servidor.py
@@ -35,6 +35,7 @@ class TestSimpleHTTPServer(unittest.TestCase):
         # Verifica que el contenido HTML esperado esté en la respuesta
         self.assertIn("<h1>Hola desde un servidor Python</h1>", response.text)
         self.assertIn("<p>Este es un servidor simple que responde a solicitudes GET.</p>", response.text)
+        self.assertIn("<p>Web del grupo DAS 404 FOUND.</p>", response.text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sencillamente se ha añadido una etiqueta de tipo <p>"..."</p> para añadir el texto con el nombre del grupo al fina de la web. Luego se ha añadido un self.assertIn en el test_servidor.py para comprobar que se ha incluido correctamente esta linea en la web.